### PR TITLE
Hm 10 create session

### DIFF
--- a/lib/models/session.dart
+++ b/lib/models/session.dart
@@ -3,20 +3,23 @@ class Session {
   final String name;
   final int locationRadius;
   final List<int> invitedUserIds;
+  final DateTime createdAt;
 
   Session({
-     this.id,
+    this.id,
     required this.name,
     required this.locationRadius,
     required this.invitedUserIds,
+    required this.createdAt,
   });
 
-   factory Session.fromJson(Map<String, dynamic> json) {
+  factory Session.fromJson(Map<String, dynamic> json) {
     return Session(
       id: json['id']?.toString(),
       name: json['name'],
       locationRadius: json['location_radius'],
       invitedUserIds: List<int>.from(json['invited_users_ids'] ?? []),
+      createdAt: DateTime.parse(json['created_at']),
     );
   }
 

--- a/lib/models/session.dart
+++ b/lib/models/session.dart
@@ -1,0 +1,30 @@
+class Session {
+  final String? id;
+  final String name;
+  final int locationRadius;
+  final List<int> invitedUserIds;
+
+  Session({
+     this.id,
+    required this.name,
+    required this.locationRadius,
+    required this.invitedUserIds,
+  });
+
+   factory Session.fromJson(Map<String, dynamic> json) {
+    return Session(
+      id: json['id']?.toString(),
+      name: json['name'],
+      locationRadius: json['location_radius'],
+      invitedUserIds: List<int>.from(json['invited_users_ids'] ?? []),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'location_radius': locationRadius,
+      'invited_users_ids': invitedUserIds,
+    };
+  }
+}

--- a/lib/screens/create_session.dart
+++ b/lib/screens/create_session.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:hangmatch/widgets/heading.dart';
+
+class CreateSessionScreen extends StatefulWidget {
+  const CreateSessionScreen({super.key});
+
+  @override
+  State<CreateSessionScreen> createState() => _CreateSessionScreenState();
+}
+
+class _CreateSessionScreenState extends State<CreateSessionScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: const Heading(text: 'Create session', fontSize: 25),
+      ),
+      body: Column(),
+    );
+  }
+}

--- a/lib/screens/create_session.dart
+++ b/lib/screens/create_session.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hangmatch/widgets/form_component.dart';
 import 'package:hangmatch/widgets/gradient_button.dart';
 import 'package:hangmatch/widgets/heading.dart';
+import 'package:hangmatch/widgets/slider_location.dart';
 
 class CreateSessionScreen extends StatefulWidget {
   const CreateSessionScreen({super.key});
@@ -38,23 +39,20 @@ class _CreateSessionScreenState extends State<CreateSessionScreen> {
         foregroundColor: Colors.white,
         title: const Heading(text: 'Create session', fontSize: 25),
       ),
-      body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 50),
-            child: Form(
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 25),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Form(
               key: _form,
-            
               child: FormComponent(
                 text: 'Session name',
-              
                 controller: _sessionNameController,
-              
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
-                    return 'Please enter session name.';
+                    return 'Please enter a session name.';
                   }
-              
                   return null;
                 },
                 onSaved: (value) {
@@ -62,16 +60,45 @@ class _CreateSessionScreenState extends State<CreateSessionScreen> {
                 },
               ),
             ),
-          ),
-          GradientButton(
-            width: 351,
-            height: 63,
-            text: 'START SESSION',
-            onPressed: _submit,
-          ),
-        ],
+            SizedBox(height: 35),
+
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Color(
+                  0xFFD593F7,
+                ).withAlpha((0.75 * 255).toInt()),
+              ),
+              onPressed: () {},
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.person_add, color: Colors.white, size: 24),
+                  SizedBox(width: 8),
+                  Text(
+                    'Invite friends',
+                    style: TextStyle(color: Colors.white, fontSize: 18),
+                  ),
+                ],
+              ),
+            ),
+
+            SizedBox(height: 50),
+            Text(
+              'Distance [km]',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+            ),
+
+            SliderLocation(),
+            const SizedBox(height: 80),
+            GradientButton(
+              width: 351,
+              height: 63,
+              text: 'START SESSION',
+              onPressed: _submit,
+            ),
+          ],
+        ),
       ),
     );
   }
 }
-

--- a/lib/screens/create_session.dart
+++ b/lib/screens/create_session.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:hangmatch/widgets/form_component.dart';
+import 'package:hangmatch/widgets/gradient_button.dart';
 import 'package:hangmatch/widgets/heading.dart';
 
 class CreateSessionScreen extends StatefulWidget {
@@ -9,6 +11,25 @@ class CreateSessionScreen extends StatefulWidget {
 }
 
 class _CreateSessionScreenState extends State<CreateSessionScreen> {
+  final _form = GlobalKey<FormState>();
+  final _sessionNameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _sessionNameController.dispose();
+
+    super.dispose();
+  }
+
+  void _submit() async {
+    final isValid = _form.currentState!.validate();
+
+    if (!isValid) {
+      return;
+    }
+    _form.currentState?.save();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -17,7 +38,40 @@ class _CreateSessionScreenState extends State<CreateSessionScreen> {
         foregroundColor: Colors.white,
         title: const Heading(text: 'Create session', fontSize: 25),
       ),
-      body: Column(),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 50),
+            child: Form(
+              key: _form,
+            
+              child: FormComponent(
+                text: 'Session name',
+              
+                controller: _sessionNameController,
+              
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter session name.';
+                  }
+              
+                  return null;
+                },
+                onSaved: (value) {
+                  _sessionNameController.text = value!;
+                },
+              ),
+            ),
+          ),
+          GradientButton(
+            width: 351,
+            height: 63,
+            text: 'START SESSION',
+            onPressed: _submit,
+          ),
+        ],
+      ),
     );
   }
 }
+

--- a/lib/screens/create_session.dart
+++ b/lib/screens/create_session.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:hangmatch/models/session.dart';
+import 'package:hangmatch/services/session_service.dart';
 import 'package:hangmatch/widgets/form_component.dart';
 import 'package:hangmatch/widgets/gradient_button.dart';
 import 'package:hangmatch/widgets/heading.dart';
@@ -12,6 +14,7 @@ class CreateSessionScreen extends StatefulWidget {
 }
 
 class _CreateSessionScreenState extends State<CreateSessionScreen> {
+  double _selectedRadius = 5;
   final _form = GlobalKey<FormState>();
   final _sessionNameController = TextEditingController();
 
@@ -29,6 +32,13 @@ class _CreateSessionScreenState extends State<CreateSessionScreen> {
       return;
     }
     _form.currentState?.save();
+
+    final session = Session(
+      name: _sessionNameController.text,
+      locationRadius: _selectedRadius.toInt(),
+      invitedUserIds: [],
+    );
+    await SessionService().session(context, session);
   }
 
   @override
@@ -88,7 +98,13 @@ class _CreateSessionScreenState extends State<CreateSessionScreen> {
               style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
             ),
 
-            SliderLocation(),
+            SliderLocation(
+              onChanged: (value) {
+                setState(() {
+                  _selectedRadius = value;
+                });
+              },
+            ),
             const SizedBox(height: 80),
             GradientButton(
               width: 351,

--- a/lib/screens/create_session.dart
+++ b/lib/screens/create_session.dart
@@ -37,6 +37,7 @@ class _CreateSessionScreenState extends State<CreateSessionScreen> {
       name: _sessionNameController.text,
       locationRadius: _selectedRadius.toInt(),
       invitedUserIds: [],
+      createdAt: DateTime.now(),
     );
     await SessionService().session(context, session);
   }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,12 +1,34 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:hangmatch/models/session.dart';
+import 'package:hangmatch/services/session_service.dart';
 import 'package:hangmatch/widgets/heading.dart';
 import 'package:hangmatch/widgets/home/last_session_card.dart';
 import 'package:hangmatch/widgets/home/new_session_button.dart';
 import 'package:hangmatch/widgets/home/upcoming_event_card.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  List<Session> sessions = [];
+
+  @override
+  void initState() {
+    _fetchSessions();
+    super.initState();
+  }
+
+  Future<void> _fetchSessions() async {
+    final result = await SessionService().getMySessions(context);
+    setState(() {
+      sessions = result;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -33,13 +55,24 @@ class HomeScreen extends StatelessWidget {
             ),
 
             SizedBox(height: 11),
-            NewSessionButton(),
+            NewSessionButton(onSessionCreated: _fetchSessions),
 
             Heading(text: 'Last session'),
             SizedBox(height: 22),
-            LastSessionCard(title: 'My birthday', onPressed: () {}),
-            SizedBox(height: 20),
-            LastSessionCard(title: 'Zuzia\'s meeting', onPressed: () {}),
+            if (sessions.isEmpty)
+              const Text('No sessions found.')
+            else
+              Column(
+                children: [
+                  if (sessions.isNotEmpty)
+                    LastSessionCard(title: sessions[0].name, onPressed: () {}),
+                  if (sessions.length > 1) ...[
+                    const SizedBox(height: 20),
+                    LastSessionCard(title: sessions[1].name, onPressed: () {}),
+                  ],
+                ],
+              ),
+
             SizedBox(height: 22),
             Heading(text: 'Upcoming events'),
             SizedBox(height: 22),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -22,6 +22,8 @@ class UserService {
           'repeated_password': register.repeatPassword,
         }),
       );
+      if (!context.mounted) return;
+
       final responseData = jsonDecode(response.body);
       if (response.statusCode == 200) {
         _showSnackBar(context, responseData['message'], true);
@@ -42,18 +44,22 @@ class UserService {
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({'email': login.email, 'password': login.password}),
       );
+      if (!context.mounted) return;
       final responseData = jsonDecode(response.body);
       if (response.statusCode == 200) {
         final token = responseData['access_token'];
 
         if (token != null) {
           await TokenService().saveToken(token);
+          if (!context.mounted) return;
           await getCurrentUser(context);
+          if (!context.mounted) return;
           Navigator.pushReplacement(
             context,
             MaterialPageRoute(builder: (context) => const HomeScreen()),
           );
         }
+        if (!context.mounted) return;
       } else {
         _showSnackBar(context, responseData['detail'], false);
       }
@@ -78,9 +84,10 @@ class UserService {
         'Authorization': 'Bearer $token',
       },
     );
+    if (!context.mounted) return;
     final responseData = jsonDecode(response.body);
     if (response.statusCode == 200) {
-      _showSnackBar(context, 'message: ${responseData['name']}', true);
+      _showSnackBar(context, 'Zalogowano jako: ${responseData['name']}', true);
     } else {
       _showSnackBar(context, responseData['detail'], false);
     }

--- a/lib/services/session_service.dart
+++ b/lib/services/session_service.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:hangmatch/models/session.dart';
+import 'package:hangmatch/services/token_service.dart';
+import 'package:http/http.dart' as http;
+
+class SessionService {
+  final baseUrl = Uri.parse('http://10.0.2.2:8000');
+  final storage = const FlutterSecureStorage();
+
+  Future<void> session(BuildContext context, Session session) async {
+    final url = Uri.parse('$baseUrl/sessions/');
+    final token = await TokenService().getToken();
+
+    if (token == null) {
+      return;
+    }
+
+    try {
+      final response = await http.post(
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode(session.toJson()),
+      );
+      if (!context.mounted) return;
+
+      final responseData = jsonDecode(response.body);
+      if (response.statusCode == 200) {
+        _showSnackBar(
+          context,
+          responseData['message'] ?? 'Sesja utworzona!',
+          true,
+        );
+      } else {
+        _showSnackBar(
+          context,
+          responseData['detail'] ?? 'Błąd tworzenia sesji',
+          false,
+        );
+      }
+    } catch (e) {
+      if (!context.mounted) return;
+      _showSnackBar(context, 'Wystąpił błąd: $e', false);
+    }
+  }
+
+  Future<List<Session>> getMySessions(BuildContext context) async {
+    try {
+      final url = Uri.parse('$baseUrl/sessions/me');
+      final token = await TokenService().getToken();
+
+      if (token == null) {
+        return [];
+      }
+
+      final response = await http.get(
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+      );
+      if (!context.mounted) return [];
+      final responseData = jsonDecode(response.body);
+      if (response.statusCode == 200) {
+        if (responseData is List) {
+          return responseData.map((json) => Session.fromJson(json)).toList();
+        } else {
+          _showSnackBar(context, 'Niepoprawny format danych.', false);
+          return [];
+        }
+      } else {
+        _showSnackBar(
+          context,
+          responseData['detail'] ?? 'Błąd pobierania sesji',
+          false,
+        );
+        return [];
+      }
+    } catch (e) {
+      _showSnackBar(context, 'Wystąpił błąd: $e', false);
+      return [];
+    }
+  }
+
+  void _showSnackBar(BuildContext context, String message, bool success) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        backgroundColor: success ? Colors.green : Colors.red,
+        content: Text(message),
+      ),
+    );
+  }
+}

--- a/lib/widgets/home/new_session_button.dart
+++ b/lib/widgets/home/new_session_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hangmatch/screens/create_session.dart';
 
 class NewSessionButton extends StatelessWidget {
   const NewSessionButton({super.key});
@@ -8,7 +9,13 @@ class NewSessionButton extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(31),
       child: ElevatedButton(
-        onPressed: () {},
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => const CreateSessionScreen(),
+            ),
+          );
+        },
         style: ElevatedButton.styleFrom(
           backgroundColor: Color(0xFFD593F7).withAlpha((0.75 * 255).toInt()),
           minimumSize: Size(342, 98),

--- a/lib/widgets/home/new_session_button.dart
+++ b/lib/widgets/home/new_session_button.dart
@@ -2,19 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:hangmatch/screens/create_session.dart';
 
 class NewSessionButton extends StatelessWidget {
-  const NewSessionButton({super.key});
+  final VoidCallback onSessionCreated;
+
+  const NewSessionButton({super.key, required this.onSessionCreated});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(31),
       child: ElevatedButton(
-        onPressed: () {
-          Navigator.of(context).push(
+        onPressed: () async {
+          final result = await Navigator.of(context).push(
             MaterialPageRoute(
               builder: (context) => const CreateSessionScreen(),
             ),
           );
+          if (result == true) {
+            onSessionCreated();
+          }
         },
         style: ElevatedButton.styleFrom(
           backgroundColor: Color(0xFFD593F7).withAlpha((0.75 * 255).toInt()),

--- a/lib/widgets/slider_location.dart
+++ b/lib/widgets/slider_location.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+class SliderLocation extends StatefulWidget {
+  const SliderLocation({super.key});
+
+  @override
+  State<SliderLocation> createState() => _SliderLocationState();
+}
+
+class _SliderLocationState extends State<SliderLocation> {
+  double _value = 0;
+  final double _min = 0;
+  final double _max = 100;
+
+  @override
+  Widget build(BuildContext context) {
+    const double sliderWidth = 350;
+
+    double percent = (_value - _min) / (_max - _min);
+    double indicatorLeft = percent * (sliderWidth - 32);
+
+    return SizedBox(
+      width: sliderWidth,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Stack(
+            alignment: Alignment.centerLeft,
+            children: [
+              Slider(
+                value: _value,
+                min: _min,
+                max: _max,
+                activeColor: Color(0xFFF5BBEC),
+                onChanged: (newValue) {
+                  setState(() {
+                    _value = newValue;
+                  });
+                },
+              ),
+              Positioned(
+                left: indicatorLeft,
+                top: 36,
+
+                child: Container(
+                  width: 40,
+                  alignment: Alignment.center,
+                  child: Text(
+                    _value.toStringAsFixed(0),
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Color(0xFFD593F7),
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 32),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/slider_location.dart
+++ b/lib/widgets/slider_location.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
 class SliderLocation extends StatefulWidget {
-  const SliderLocation({super.key});
+  final Function(double)? onChanged;
+  const SliderLocation({super.key, this.onChanged});
 
   @override
   State<SliderLocation> createState() => _SliderLocationState();
@@ -10,7 +11,7 @@ class SliderLocation extends StatefulWidget {
 class _SliderLocationState extends State<SliderLocation> {
   double _value = 0;
   final double _min = 0;
-  final double _max = 100;
+  final double _max = 400;
 
   @override
   Widget build(BuildContext context) {
@@ -36,6 +37,9 @@ class _SliderLocationState extends State<SliderLocation> {
                   setState(() {
                     _value = newValue;
                   });
+                  if (widget.onChanged != null){
+                    widget.onChanged!(newValue);
+                  }
                 },
               ),
               Positioned(


### PR DESCRIPTION
- CreateSessionScreen – a new screen for creating activity sessions
- Session model – the session data structure including name, location, and participants
- Navigation – switching from the "New Session" button to CreateSessionScreen
- SliderLocation widget – a widget for selecting the session location radius
- InviteFriend button – the ability to invite friends to a session
- Backend integration – creating a session via the API and saving it in the database

**Testing**
- Tested on an Android emulator
- Creation of sessions and feedback display were verified.
- Proper navigation and integration with the backend were verified.

<img width="1080" height="2160" alt="HomeScreen-backend" src="https://github.com/user-attachments/assets/c087929e-645a-4533-9079-e02f7cc0859f" />


<img width="1080" height="2160" alt="CreateSession" src="https://github.com/user-attachments/assets/365a4486-3194-4bc8-bcd1-86bebcf90ce2" />


<img width="884" height="161" alt="Zrzut ekranu 2025-07-15 232545" src="https://github.com/user-attachments/assets/3ebbbabd-5d00-46ba-b8a0-3e5fde2f67fa" />

