### PR TITLE
Hm 12 friends screen

### DIFF
--- a/lib/screens/explore.dart
+++ b/lib/screens/explore.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class ExploreScreen extends StatelessWidget {
+  const ExploreScreen({super.key});
+  @override
+  Widget build(BuildContext context) => const Center(child: Text('Explore'));
+}

--- a/lib/screens/profile.dart
+++ b/lib/screens/profile.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+  @override
+  Widget build(BuildContext context) => const Center(child: Text('Profile'));
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:hangmatch/screens/home.dart';
 import 'package:hangmatch/services/token_service.dart';
+import 'package:hangmatch/widgets/modern_navigation_bar.dart';
 import 'package:http/http.dart' as http;
 import 'package:hangmatch/models/user.dart';
 
@@ -51,7 +51,7 @@ class UserService {
           await getCurrentUser(context);
           Navigator.pushReplacement(
             context,
-            MaterialPageRoute(builder: (context) => const HomeScreen()),
+            MaterialPageRoute(builder: (context) => const ModernNavigationBar()),
           );
         }
       } else {

--- a/lib/widgets/modern_navigation_bar.dart
+++ b/lib/widgets/modern_navigation_bar.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:hangmatch/screens/explore.dart';
+import 'package:hangmatch/screens/friends.dart';
+import 'package:hangmatch/screens/home.dart';
+import 'package:hangmatch/screens/profile.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+
+class ModernNavigationBar extends StatefulWidget {
+  const ModernNavigationBar({super.key});
+
+  @override
+  State<ModernNavigationBar> createState() => _ModernNavigationBarState();
+}
+
+class _ModernNavigationBarState extends State<ModernNavigationBar> {
+  int _selectedIndex = 0;
+
+  final List<Widget> _screens = [
+    HomeScreen(),
+    ExploreScreen(),
+    FriendsScreen(),
+    ProfileScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _screens[_selectedIndex],
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          color: Colors.black.withOpacity(0.7),
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(24),
+            topRight: Radius.circular(24),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.3),
+              blurRadius: 10,
+              offset: const Offset(0, -3),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(24),
+            topRight: Radius.circular(24),
+          ),
+          child: Theme(
+            data: Theme.of(context).copyWith(
+              splashFactory: NoSplash.splashFactory,
+              splashColor: Colors.transparent,
+            ),
+            child: BottomNavigationBar(
+              currentIndex: _selectedIndex,
+              onTap: (index) => setState(() => _selectedIndex = index),
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+              selectedItemColor: Colors.white,
+              unselectedItemColor: Colors.white.withOpacity(0.5),
+              showSelectedLabels: false,
+              showUnselectedLabels: false,
+              type: BottomNavigationBarType.fixed,
+              selectedIconTheme: const IconThemeData(size: 24, color: const Color(0xFFD593F7),),
+              unselectedIconTheme: IconThemeData(size: 24, color: Colors.white.withOpacity(0.5)),
+              items: const [
+                BottomNavigationBarItem(
+                  icon: Icon(LucideIcons.home),
+                  label: 'Home',
+                ),
+                BottomNavigationBarItem(
+                  icon: Icon(LucideIcons.compass),
+                  label: 'Explore',
+                ),
+                BottomNavigationBarItem(
+                  icon: Icon(LucideIcons.users),
+                  label: 'Friends',
+                ),
+                BottomNavigationBarItem(
+                  icon: Icon(LucideIcons.user),
+                  label: 'Profile',
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   flutter_native_splash: ^2.4.6
   http: ^1.4.0
   flutter_secure_storage: ^9.2.4
+  lucide_icons: ^0.257.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR introduces the FriendsScreen, a new friend management screen with a modern navigation system. 

- Ability to browse your friends list
- Accepting/declining invitations (no functionality)
- Responsive container with styled borders

- **New navigation system (`ModernNavigationBar`)**
- Bottom navigation with icons
- Integration with `ExploreScreen` and `ProfileScreen`
- Replacing the previous `HomeScreen` with a new system

- `FriendsScreen` - main friend management screen
- `ExploreScreen` - blank screen for future implementation
- `ProfileScreen` - blank screen for future implementation

- Added `lucide_icons` library for icons
- Updated application navigation
- Stylistic improvements and added borders

- The `ExploreScreen` and `ProfileScreen` screens are currently blank and require future implementation

<img width="1080" height="2160" alt="Screenshot_20251103_154820" src="https://github.com/user-attachments/assets/6ee7ecc9-65cf-46cf-95f5-280847703791" />


